### PR TITLE
walk not only content node

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,12 @@ function getEntities(bemjson, ctx) {
 
         bemjson.mix && (deps = deps.concat(_getEntities(bemjson.mix, ctx)));
 
+        var forbiddenKeys = ['content', 'mods', 'js', 'attrs']
+        Object.keys(bemjson).filter(function(key) {
+            return forbiddenKeys.indexOf(key) == -1;
+        }).forEach(function(key) {
+            deps = deps.concat(_getEntities(bemjson[key], ctx));
+        });
         bemjson.content && (deps = deps.concat(_getEntities(bemjson.content, ctx)));
 
         return deps.filter(Boolean);

--- a/test/reference4.deps.js
+++ b/test/reference4.deps.js
@@ -1,0 +1,6 @@
+module.exports = [
+    { block: 'page' },
+    { modName: 'theme', modVal: 'islands', block: 'page' },
+    { block: 'page', elem: 'css' },
+    { block: 'page', elem: 'script' }
+];

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,8 @@
 var inspect = require('util').inspect,
     assert = require('assert'),
     bemjsonToDecl = require('..'),
-    testsNumber = 3;
+    testsNumber = 4,
+    errorsCount = 0;
 
 while (testsNumber) {
     var bemjson = require('./test' + testsNumber + '.bemjson.js'),
@@ -10,13 +11,16 @@ while (testsNumber) {
     try {
         assert.deepEqual(bemjsonToDecl.convert(bemjson), reference, 'Test #' + testsNumber + ' failed');
     } catch(err) {
-        console.log('bemjson', bemjson);
-
         console.log(err.message);
+        console.log('bemjson', bemjson);
         console.log('convert\n', bemjsonToDecl.convert(bemjson));
         console.log('\nreference\n', inspect(reference, { depth: null }));
-        throw new Error(err);
+        errorsCount++;
     }
 
     testsNumber--;
+}
+
+if(errorsCount > 0) {
+    throw new Error('Tests have been failed');
 }

--- a/test/test4.bemjson.js
+++ b/test/test4.bemjson.js
@@ -1,0 +1,8 @@
+module.exports = {
+    block: 'page',
+    mods: { theme: 'islands'},
+    head: [{
+        elem: 'css'
+    }],
+    scripts: {elem: 'script'}
+}


### PR DESCRIPTION
block page has elements not only on the `content` property. 
Dependencies should be discovered on every node except few reserved.

This is how ENB works as well: https://github.com/enb-bem/enb-bem-techs/blob/master/techs/bemjson-to-bemdecl.js#L157